### PR TITLE
Remove redundant default value setting for sessionKey and sessionErrorKey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,8 @@ export const createStrapiStrategy = (
         {
             strapiClient,
             sessionStorage,
-            sessionKey: sessionKey ? sessionKey : 'strapi:session',
-            sessionErrorKey: sessionErrorKey ? sessionErrorKey : 'strapi:error',
+            sessionKey: sessionKey ?? 'strapi:session',
+            sessionErrorKey: sessionErrorKey ?? 'strapi:error',
         },
         async ({ request, strapiClient }) => {
             const form = await request.formData()

--- a/src/strapi-strategy.ts
+++ b/src/strapi-strategy.ts
@@ -17,9 +17,9 @@ export interface StrapiStrategyOptions {
 
     readonly sessionStorage: SessionStorage
 
-    readonly sessionKey?: string
+    readonly sessionKey: string
 
-    readonly sessionErrorKey?: string
+    readonly sessionErrorKey: string
 }
 
 export interface VerifyParams {
@@ -59,8 +59,8 @@ export class StrapiStrategy extends Strategy<StrapiAuthResponse, VerifyParams> {
 
         this.strapiClient = options.strapiClient
         this.sessionStorage = options.sessionStorage
-        this.sessionKey = options.sessionKey ?? 'strapi-auth:session'
-        this.sessionErrorKey = options.sessionErrorKey ?? 'strapi-auth:error'
+        this.sessionKey = options.sessionKey
+        this.sessionErrorKey = options.sessionErrorKey
     }
 
     async authenticate(


### PR DESCRIPTION
There are no tests unfortunately. But typecheck goes through smoothly.